### PR TITLE
[deprecate-cgi] get charset without using cgi

### DIFF
--- a/requests_har/har.py
+++ b/requests_har/har.py
@@ -6,7 +6,7 @@ the HTTP archive format.
 
 import json
 import pathlib
-from cgi import parse_header
+from email.message import EmailMessage
 from collections import OrderedDict
 from datetime import datetime
 from http import HTTPStatus, cookiejar
@@ -56,11 +56,10 @@ def get_charset(headers: structures.CaseInsensitiveDict[str]) -> str:
     :return: Charset of the response
     :rtype: str
     """
-    header = headers.get("Content-Type", "application/json; charset=utf-8")
-    parsed = parse_header(header)
-    if len(parsed) == 1:
-        return "utf-8"
-    return parsed[1].get("charset", "utf-8")
+    # alternative of cgi.parse_header() according to https://peps.python.org/pep-0594/#cgi
+    m = EmailMessage()
+    m['content-type'] = headers.get("Content-Type", "application/json; charset=utf-8")
+    return m.get_content_charset('utf-8')
 
 
 def format_query(url: str) -> List[HARQueryParam]:


### PR DESCRIPTION
Instead of the deprecated `cgi.parse_header()`, use `email.message.EmailMessage` to parse `Content-Type` header and extract charset.

## The Problem

See [PEP 594](https://peps.python.org/pep-0594/#cgi), the `cgi` module
is deprecated since version 3.11 and will be removed in version 3.13.

Thus creating the following lint error:

```console
$ make lint
poetry run pylint requests_har
************* Module requests_har.har
requests_har/har.py:9:0: W4901: Deprecated module 'cgi' (deprecated-module)

------------------------------------------------------------------
Your code has been rated at 9.94/10 (previous run: 9.94/10, +0.00)

make: *** [lint] Error 4
```

And test warning:

```console
$ make test
poetry run pytest
======================================================= test session starts ========================================================
platform darwin -- Python 3.11.6, pytest-7.4.4, pluggy-1.5.0
rootdir: /Users/jeff_hung/wc/NoteBrainer/requests_har
plugins: pylama-8.4.1
collected 1 item

tests/test_har.py .                                                                                                          [100%]

========================================================= warnings summary =========================================================
requests_har/har.py:9
  /Users/jeff_hung/wc/NoteBrainer/requests_har/requests_har/har.py:9: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    from cgi import parse_header

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================== 1 passed, 1 warning in 0.16s ===================================================
```

The mitigation, as suggested in [`cgi.parse_header()`](https://docs.python.org/3/library/cgi.html#cgi.parse_header) document,
is to use `email.message.EmailMessage` instead.

See also:
* [python-babel #876: Use email.Message for pofile header parsing](https://github.com/python-babel/babel/pull/876)
 

## After Fix

```console
$ make lint
poetry run pylint requests_har

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ make test
poetry run pytest
======================================================= test session starts ========================================================
platform darwin -- Python 3.11.6, pytest-7.4.4, pluggy-1.5.0
rootdir: /Users/jeff_hung/wc/NoteBrainer/requests_har
plugins: pylama-8.4.1
collected 1 item

tests/test_har.py .                                                                                                          [100%]

======================================================== 1 passed in 0.15s =========================================================
```